### PR TITLE
Prepare release of v0.3.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 exclude = [".github/"]
 readme = "README.md"
 name = "dbus-secret-service-keyring-store"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 
 [features]

--- a/src/store.rs
+++ b/src/store.rs
@@ -17,7 +17,10 @@ pub struct Store {
 
 impl std::fmt::Debug for Store {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Store").field("id", &self.id).finish()
+        f.debug_struct("Store")
+            .field("vendor", &self.vendor())
+            .field("id", &self.id())
+            .finish()
     }
 }
 


### PR DESCRIPTION
This cosmetic release just adds the vendor to the debug info for stores. There are no functional changes.