### PR TITLE
Prepare to release v0.4.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,8 +4,6 @@ on: [ workflow_dispatch, push, pull_request ]
 
 jobs:
   ci_stable:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         features:
@@ -13,6 +11,12 @@ jobs:
           - "crypto-openssl"
           - "crypto-rust,vendored"
           - "crypto-openssl,vendored"
+        platform:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+
+    runs-on:
+      - ${{ matrix.platform }}
 
     steps:
       - name: install required packages
@@ -73,7 +77,7 @@ jobs:
       - name: Install rust MSRV
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          toolchain: 1.85
+          toolchain: 1.88
           components: clippy
 
       - name: Clippy check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,11 @@ homepage = "https://github.com/open-source-cooperative/keyring-rs/wiki/Keyring"
 keywords = ["dbus", "secret-service", "credential-store", "keyring"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/open-source-cooperative/dbus-secret-service-keyring-store.git"
-rust-version = "1.85"
+rust-version = "1.88"
 exclude = [".github/"]
 readme = "README.md"
 name = "dbus-secret-service-keyring-store"
-version = "0.3.3"
+version = "1.0.0"
 edition = "2024"
 
 [features]
@@ -17,16 +17,15 @@ crypto-rust = ["dbus-secret-service/crypto-rust"]
 crypto-openssl = ["dbus-secret-service/crypto-openssl"]
 vendored = ["dbus-secret-service/vendored"]
 
-[[example]]
-name = "example"
-
 [dependencies]
 dbus-secret-service = { version = "4.1" }
-keyring-core = {  version = "0.7" }
+keyring-core = { version = "1" }
 
 [dev-dependencies]
-fastrand = "2.3.0"
+fastrand = "2.4"
+regex = "1.12"
+sscanf = "0.5"
 
 [package.metadata.docs.rs]
-features = ["crypto-rust"]
 targets = ["x86_64-unknown-linux-gnu"]
+features = ["crypto-rust"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To use this credential store provider, you must take a dependency on the [keyrin
 
 ## Features
 
-This crate has no features of its own: all of its features are simply passed on to the [dbus-secret-service crate](https://crates.io/crates/dbus-secret-service) that it uses to communicate with Secret Service. (See the [docs for that crate](https://docs.rs/docs/dbus-secret-service) for details.) You must enable either the `crypto-rust` or the `crypto-openssl` feature because this crate always encrypts communication with the Secret Service. You can additionally enable the `vendored` feature if you want the required C libraries (dbus and, if specified, openssl) statically linked with your application.
+You must enable either the `crypto-rust` or the `crypto-openssl` feature because this crate always encrypts communication with the Secret Service. You can additionally enable the `vendored` feature if you want the required C libraries (dbus and, if specified, openssl) statically linked with your application.
 
 ## Changelog
 

--- a/examples/cleanup.rs
+++ b/examples/cleanup.rs
@@ -1,0 +1,103 @@
+//! Example CLI app that finds and prints Secret Service credentials
+//! that were probably created while testing this crate.
+//! You can specify arguments to delete the entries (`-h` or `--help` for usage).
+use std::collections::HashMap;
+
+use regex::Regex;
+use sscanf::sscanf;
+
+use dbus_secret_service_keyring_store::Store;
+use keyring_core::{Entry, Error, Result, set_default_store};
+
+fn main() -> Result<()> {
+    set_default_store(Store::new()?);
+    let (names, entries) = find_candidates()?;
+    let args = std::env::args().skip(1).collect::<Vec<String>>();
+    if args.len() > 1 {
+        println!("Usage: cleanup [-a | --all | start-end | index]");
+        std::process::exit(1);
+    }
+    if args.is_empty() {
+        show_progress(&names, &entries, false, 1, names.len())?;
+    } else {
+        let arg = args[0].as_str();
+        if arg == "-h" || arg == "--help" {
+            println!("Usage: cleanup [-a | --all | start-end | index]");
+        } else if arg == "-a" || arg == "--all" {
+            show_progress(&names, &entries, true, 1, names.len())?;
+        } else if let Some((start, end)) = sscanf!(arg, "{}-{}", usize, usize) {
+            show_progress(&names, &entries, true, start, end)?;
+        } else if let Some(index) = sscanf!(arg, "{}", usize) {
+            show_progress(&names, &entries, true, index, index)?;
+        } else {
+            println!("Usage: cleanup [-a | --all | start-end | index]");
+            std::process::exit(1);
+        }
+    }
+    Ok(())
+}
+
+fn find_candidates() -> Result<(Vec<String>, Vec<Entry>)> {
+    let pattern = Regex::new(r"(^test-.+)|(\b\w{12}\b)|(\b\w{30}\b)").unwrap();
+    let candidates = Entry::search(&HashMap::new())?;
+    let mut names = Vec::new();
+    let mut entries = Vec::new();
+    for entry in candidates {
+        if let Some(specs) = entry.get_specifiers()
+            && (pattern.is_match(&specs.0) || pattern.is_match(&specs.1))
+        {
+            names.push(format!("service: {}, user: {}", specs.0, specs.1));
+            entries.push(entry);
+        }
+    }
+    Ok((names, entries))
+}
+
+fn show_progress(
+    names: &[String],
+    entries: &[Entry],
+    is_deleting: bool,
+    start: usize,
+    end: usize,
+) -> Result<()> {
+    if names.is_empty() {
+        if is_deleting {
+            println!("No candidates found to delete.");
+        } else {
+            println!("No candidates found.");
+        }
+        return Ok(());
+    }
+    if start < 1 {
+        return Err(Error::Invalid(
+            start.to_string(),
+            "out of range".to_string(),
+        ));
+    }
+    if end > names.len() {
+        return Err(Error::Invalid(end.to_string(), "out of range".to_string()));
+    }
+    if start > end {
+        return Err(Error::Invalid(
+            format!("{start}-{end}"),
+            "invalid range".to_string(),
+        ));
+    }
+    let found = if names.len() == 1 {
+        "Found 1 candidate".to_string()
+    } else {
+        format!("Found {} candidates", names.len())
+    };
+    if is_deleting {
+        println!("{found}; deleting {}:", end - start + 1);
+    } else {
+        println!("{found}:");
+    }
+    for i in start..=end {
+        println!("{i: >3} - {}", names[i - 1]);
+        if is_deleting {
+            entries[i - 1].delete_credential()?
+        }
+    }
+    Ok(())
+}

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,5 +1,5 @@
 //! Example CLI app that creates, writes, reads, examines, and deletes an entry
-//! in the keyutils keystore using APIs from the keyring crate.
+//! in the Secret Service using APIs from the keyring crate.
 use std::collections::HashMap;
 
 use dbus_secret_service_keyring_store::{Store, cred::Specifier};
@@ -9,8 +9,8 @@ fn main() {
     // Set secret service backend as the default store
     keyring_core::set_default_store(Store::new().unwrap());
 
-    let service = "service-name";
-    let user = "user-name";
+    let service = "test-service";
+    let user = "test-user";
     let password1 = "<PASSWORD1>";
     let password2 = "<PASSWORD2>";
     let entry1 = Entry::new(service, user).unwrap();
@@ -19,7 +19,7 @@ fn main() {
     if retrieved != password1 {
         panic!("Passwords do not match");
     }
-    println!("Entry with no target: {:?}", entry1);
+    println!("Entry with no target: {entry1:?}");
     let modifiers = HashMap::from([("target", "my-special-collection")]);
     let entry2 = Entry::new_with_modifiers(service, user, &modifiers).unwrap();
     entry2.set_password(password2).unwrap();
@@ -27,7 +27,7 @@ fn main() {
     if retrieved != password2 {
         panic!("Passwords do not match");
     }
-    println!("Entry with a custom target: {:?}", entry2);
+    println!("Entry with a custom target: {entry2:?}");
     // service and user of entry1 are the same as entry2, but it has no target attribute
     assert!(matches!(
         entry1.get_password().unwrap_err(),

--- a/src/cred.rs
+++ b/src/cred.rs
@@ -103,8 +103,8 @@ impl Specifier {
         let mut result: HashMap<&str, &str> = HashMap::new();
         result.insert("service", self.service.as_str());
         result.insert("username", self.user.as_str());
-        if self.target.is_some() {
-            result.insert("target", self.target.as_ref().unwrap());
+        if let Some(target) = &self.target {
+            result.insert("target", target.as_str());
         }
         result
     }
@@ -211,6 +211,11 @@ impl Wrapper {
         self.ss.ensure_unlocked(&self.path)?;
         self.ss.set_label(&self.path, label)
     }
+
+    /// Gets the path of the wrapped item.
+    pub fn get_path(&self) -> String {
+        self.path.to_string()
+    }
 }
 
 impl CredentialApi for Wrapper {
@@ -256,10 +261,10 @@ impl CredentialApi for Wrapper {
             return None;
         }
         let attributes = self.ss.get_attributes(&self.path).unwrap_or_default();
-        if let Some(service) = attributes.get("service") {
-            if let Some(user) = attributes.get("username") {
-                return Some((service.to_string(), user.to_string()));
-            }
+        if let Some(service) = attributes.get("service")
+            && let Some(user) = attributes.get("username")
+        {
+            return Some((service.to_string(), user.to_string()));
         }
         None
     }


### PR DESCRIPTION
1. Add a cleanup example for failed tests.
2. Move MSRV to 1.88; use let chaining.
3. Move to keyring-core 1.0
4. Minor tweaks to naming in the example.
5. fix clippy problems
6. Update the README feature docs.
7. Make CI build on ARM as well as x86.
8. Update dependencies (sscanf API changes)