### PR TITLE
Use application/octet-stream when updating a secret's value

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -111,7 +111,8 @@ impl Service {
             .lock()
             .expect("Mutex failure in credential store: please report a bug");
         let item = Item::new(&ss, path.clone());
-        item.set_secret(secret, "text/plain").map_err(decode_error)
+        item.set_secret(secret, "application/octet-stream")
+            .map_err(decode_error)
     }
 
     /// Given an existing item's path, retrieve its secret.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -187,6 +187,21 @@ fn test_update() {
 }
 
 #[test]
+fn test_update_secret() {
+    let name = generate_random_string();
+    let entry = entry_new(&name, &name);
+    // 0xFF can never appear in UTF-8, so these secrets are unambiguously binary
+    let mut initial = generate_random_bytes();
+    initial.push(0xFF);
+    entry
+        .set_secret(&initial)
+        .unwrap_or_else(|err| panic!("Can't set initial secret: {err:?}"));
+    let mut updated = generate_random_bytes();
+    updated.push(0xFF);
+    test_round_trip_secret("updated binary secret", &entry, &updated);
+}
+
+#[test]
 fn test_get_update_attributes() {
     let name1 = generate_random_string();
     let name2 = generate_random_string();


### PR DESCRIPTION
Fixes #12.

`set_secret` on an existing item, declared the payload as `text/plain`
even for arbitrary binary data. 
Secret Service implementations can reject such writes — ksecretd (KDE's daemon) returns:

```
org.freedesktop.DBus.Error.InvalidArgs
"Secret value contains invalid UTF-8 sequences but content_type declares
text encoding; use application/octet-stream for binary data"
```

gnome-keyring doesn't validate, so this goes unnoticed on GNOME.

The bug turned out to be narrower than #12 implies: *creating* an item
already declares `application/octet-stream` (`create_item` in
`src/service.rs`), so first writes succeed everywhere. Only the
in-place *update* path used `text/plain`. That's also why the existing
test suite never caught it - each test writes an entry only once. Apps
that re-save a secret they already stored (eg Proton Authenticator,
where this was originally hit - see
open-source-cooperative/keyring-rs#347) fail on the second write.

This actually completes 9099b5f (#7), which switched the create path to
`application/octet-stream` for the same reason.

## Changes

- `src/service.rs`: the item-update `set_secret` now declares
  `application/octet-stream`, matching what `create_item` already does.
- `src/tests.rs`: new `test_update_secret`, an overwrite round-trip
  whose secrets end in `0xFF` (never valid in UTF-8) so the payload is
  unambiguously binary.

## Backward compatibility

The read path never inspects the stored content type, and ksecretd
validates only on write, so items previously stored as `text/plain`
remain readable unchanged. Verified live: octet-stream items read back
byte-identical.

Note this means passwords set via the update path are now also labelled
`application/octet-stream` - consistent with the create path, which has
always labelled passwords that way.

## Testing

CI runs against gnome-keyring, which doesn't validate content types, so
the new test passes there with or without the fix — CI cannot reproduce
this bug. It was instead verified on a live validating daemon (ksecretd
from kwallet 6.28.0, KDE Plasma 6, CachyOS/Arch):

- unfixed code: `test_update_secret` fails with the exact InvalidArgs
  error above;
- with this change: full suite passes (20 passed, 1 ignored), plus
  `cargo fmt --check` and `cargo clippy --no-deps --all-targets -- -D
  warnings` clean (`--features=crypto-rust`).

The same fix, verified the same way, is being submitted to
zbus-secret-service-keyring-store (its issue #13).
